### PR TITLE
Define some error code to prepare for retry logic

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,7 +300,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause, queue.Resume, env.ConcurrencyStateEndpoint)
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause, queue.Resume, env.ConcurrencyStateEndpoint, queue.ConcurrencyStateTokenVolumeMountPath)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,8 +300,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
-		logger.Info("Concurrency state endpoint set, tracking request counts")
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, nil, nil)
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause, queue.Resume, env.ConcurrencyStateEndpoint)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "e3a807cf"
+    knative.dev/example-checksum: "e82fcbd0"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "d42e2c33"
+    knative.dev/example-checksum: "e3a807cf"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -81,7 +81,9 @@ data:
     queueSidecarEphemeralStorageLimit: "1024Mi"
 
     # concurrencyStateEndpoint is the endpoint that queue-proxy calls when its traffic
-    # drops to zero or scales up from zero.
+    # drops to zero or scales up from zero. The endpoint will need to include both
+    # the endpoint and the port that will be accessed, for example:
+    # http://pod-freezer.knative-serving.svc.cluster.local:9696
     # If omitted, queue proxy takes no action (this is the default behavior).
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
     concurrencyStateEndpoint: ""

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -85,5 +85,10 @@ data:
     # the endpoint and the port that will be accessed, for example:
     # http://pod-freezer.knative-serving.svc.cluster.local:9696
     # If omitted, queue proxy takes no action (this is the default behavior).
+    # When enabled, a serviceAccountToken will be mounted to queue-proxy using a
+    # projected volume. This requires the Service Account Token Volume Projection feature
+    # to be enabled. For details, see this link:
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+    #
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
     concurrencyStateEndpoint: ""

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -136,7 +136,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 func FreezePodRetry(logger *zap.SugaredLogger, ch chan RetryElement, token *Token, pause, resume func(string, *Token) (int8, error)) {
 	for {
 		elementNow := <-ch
-		ch <- RetryElement{} // stub this channel till handled
+		ch <- RetryElement{} // keep this channel owned till handled
 		elementNow.timesNow += 1
 		if elementNow.timesNow > FreezeMaxRetryTimes {
 			panic("Relaunch a pod")

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -29,7 +29,7 @@ import (
 )
 
 const ConcurrencyStateTokenVolumeMountPath = "/var/run/secrets/tokens"
-const FreezeMaxRetryTimes = 5 // If pause/resume failed 5 times, it should relaunch a pod
+const FreezeMaxRetryTimes = 3 // If pause/resume failed 5 times, it should relaunch a pod
 
 // error code for exec Pause/Resume function
 const (
@@ -145,20 +145,20 @@ func FreezePodRetry(logger *zap.SugaredLogger, ch chan RetryElement, retryDoneCh
 		}
 		switch elementNow.op {
 		case "pause":
-			time.Sleep(time.Second)
 			errCode, err := pause(elementNow.endpoint, token)
 			if errCode != responseStatusConflictError && errCode != noError {
 				logger.Info("Error handling pause request: %v", err)
 				ch <- elementNow
+				time.Sleep(100 * time.Millisecond)
 			} else {
 				retryDoneChannel <- struct{}{}
 			}
 		case "resume":
-			time.Sleep(time.Second)
 			errCode, err := resume(elementNow.endpoint, token)
 			if errCode != responseStatusConflictError && errCode != noError {
 				logger.Info("Error handling resume request: %v", err)
 				ch <- elementNow
+				time.Sleep(100 * time.Millisecond)
 			} else {
 				retryDoneChannel <- struct{}{}
 			}

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -25,6 +25,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const ConcurrencyStateTokenVolumeMountPath = "/var/run/secrets/tokens"
+
 // ConcurrencyStateHandler tracks the in flight requests for the pod. When the requests
 // drop to zero, it runs the `pause` function, and when requests scale up from zero, it
 // runs the `resume` function. If either of `pause` or `resume` are not passed, it runs

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -133,11 +133,13 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 	}
 }
 
+// FreezePodRetry handle the failed request when call Resume/Pause
 func FreezePodRetry(logger *zap.SugaredLogger, ch chan RetryElement, token *Token, pause, resume func(string, *Token) (int8, error)) {
 	for {
 		elementNow := <-ch
 		elementNow.timesNow += 1
 		if elementNow.timesNow > FreezeMaxRetryTimes {
+			// TODO: relaunch a new pod
 			panic("Relaunch a pod")
 		}
 		switch elementNow.op {

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -317,7 +317,7 @@ func BenchmarkConcurrencyStateProxyHandler(b *testing.B) {
 }
 
 // createTempTokenFile creates a temporary file with the text "0123456789" for simulating a serviceAccountToken
-// Note that it does NOT delete the temp file, this must be called seperately, for example:
+// Note that it does NOT delete the temp file, this must be called separately, for example:
 //
 // tempFile := createTempTokenFile(logger)
 // defer os.Remove(tempFile.Name())

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queue
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -74,13 +75,15 @@ func TestConcurrencyStateHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			paused := atomic.NewInt64(0)
-			pause := func() {
+			pause := func(string) error {
 				paused.Inc()
+				return nil
 			}
 
 			resumed := atomic.NewInt64(0)
-			resume := func() {
+			resume := func(string) error {
 				resumed.Inc()
+				return nil
 			}
 
 			delegated := atomic.NewInt64(0)
@@ -94,7 +97,7 @@ func TestConcurrencyStateHandler(t *testing.T) {
 				delegated.Inc()
 			}
 
-			h := ConcurrencyStateHandler(logger, http.HandlerFunc(delegate), pause, resume)
+			h := ConcurrencyStateHandler(logger, http.HandlerFunc(delegate), pause, resume, "")
 
 			var wg sync.WaitGroup
 			wg.Add(len(tt.events))
@@ -127,6 +130,100 @@ func TestConcurrencyStateHandler(t *testing.T) {
 				t.Errorf("expected to be resumed %d times, but was resumed %d times", want, got)
 			}
 		})
+	}
+}
+
+func TestPauseHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range r.Header {
+			if k == "Token" {
+				// TODO update when using token
+				if v[0] != "nil" {
+					t.Errorf("incorrect token header, expected 'nil', got %s", v)
+				}
+			}
+		}
+	}))
+	err := Pause(ts.URL)
+	if err != nil {
+		t.Errorf("pause header check returned an error: %s", err)
+	}
+}
+
+func TestPauseRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		var m ConcurrencyStateMessageBody
+		err := json.NewDecoder(r.Body).Decode(&m)
+		if err != nil {
+			t.Errorf("unable to parse message body: %s", err)
+		}
+		if m.Action != "pause" {
+			t.Errorf("improper message body, expected 'freeze' and got: %s", m.Action)
+		}
+	}))
+	err := Pause(ts.URL)
+	if err != nil {
+		t.Errorf("pause request test returned an error: %s", err)
+	}
+}
+
+func TestPauseResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	err := Pause(ts.URL)
+	if err == nil {
+		t.Errorf("failed pause function did not return an error")
+	}
+}
+
+func TestResumeRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		var m ConcurrencyStateMessageBody
+		err := json.NewDecoder(r.Body).Decode(&m)
+		if err != nil {
+			t.Errorf("unable to parse message body: %s", err)
+		}
+		if m.Action != "resume" {
+			t.Errorf("improper message body, expected 'thaw' and got: %s", m.Action)
+		}
+	}))
+	err := Resume(ts.URL)
+	if err != nil {
+		t.Errorf("resume request test returned an error: %s", err)
+	}
+}
+
+func TestResumeResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	err := Resume(ts.URL)
+	if err == nil {
+		t.Errorf("failed resume function did not return an error")
+	}
+}
+
+func TestResumeHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range r.Header {
+			if k == "Token" {
+				// TODO update when using token
+				if v[0] != "nil" {
+					t.Errorf("incorrect token header, expected 'nil', got %s", v)
+				}
+			}
+		}
+	}))
+	err := Resume(ts.URL)
+	if err != nil {
+		t.Errorf("resume header check returned an error: %s", err)
 	}
 }
 
@@ -175,8 +272,14 @@ func BenchmarkConcurrencyStateProxyHandler(b *testing.B) {
 				promStatReporter.Report(stats.Report(now))
 			}
 		}()
+		pause := func(string) error {
+			return nil
+		}
+		resume := func(string) error {
+			return nil
+		}
 
-		h := ConcurrencyStateHandler(logger, ProxyHandler(tc.breaker, stats, true /*tracingEnabled*/, baseHandler), nil, nil)
+		h := ConcurrencyStateHandler(logger, ProxyHandler(tc.breaker, stats, true /*tracingEnabled*/, baseHandler), pause, resume, "")
 		b.Run("sequential-"+tc.label, func(b *testing.B) {
 			resp := httptest.NewRecorder()
 			for j := 0; j < b.N; j++ {

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -475,11 +475,12 @@ func updateContainer() containerOption {
 
 func TestMakePodSpec(t *testing.T) {
 	tests := []struct {
-		name string
-		rev  *v1.Revision
-		oc   metrics.ObservabilityConfig
-		dc   *apicfg.Defaults
-		want *corev1.PodSpec
+		name     string
+		rev      *v1.Revision
+		oc       metrics.ObservabilityConfig
+		defaults *apicfg.Defaults
+		dc       deployment.Config
+		want     *corev1.PodSpec
 	}{{
 		name: "user-defined user port, queue proxy have PORT env",
 		rev: revision("bar", "foo",
@@ -583,7 +584,7 @@ func TestMakePodSpec(t *testing.T) {
 			}, func(p *corev1.PodSpec) {
 				p.EnableServiceLinks = ptr.Bool(true)
 			}),
-		dc: func() *apicfg.Defaults {
+		defaults: func() *apicfg.Defaults {
 			d, _ := apicfg.NewDefaultsConfigFromMap(map[string]string{
 				"enable-service-links": "true",
 			})
@@ -610,7 +611,7 @@ func TestMakePodSpec(t *testing.T) {
 			}, func(p *corev1.PodSpec) {
 				p.EnableServiceLinks = nil
 			}),
-		dc: func() *apicfg.Defaults {
+		defaults: func() *apicfg.Defaults {
 			d, _ := apicfg.NewDefaultsConfigFromMap(map[string]string{
 				"enable-service-links": "default",
 			})
@@ -1087,14 +1088,55 @@ func TestMakePodSpec(t *testing.T) {
 			},
 			withAppendedVolumes(varLogVolume),
 		),
+	}, {
+		name: "concurrency state projected volume",
+		dc: deployment.Config{
+			ConcurrencyStateEndpoint: "freeze-proxy",
+		},
+		rev: revision("bar", "foo",
+			withContainers([]corev1.Container{{
+				Name:           servingContainerName,
+				Image:          "busybox",
+				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
+				Ports:          buildContainerPorts(v1.DefaultUserPort),
+			}, {
+				Name:  sidecarContainerName,
+				Image: "ubuntu",
+			}}),
+			WithContainerStatuses([]v1.ContainerStatus{{
+				ImageDigest: "busybox@sha256:deadbeef",
+			}, {
+				ImageDigest: "ubuntu@sha256:deadbeef",
+			}}),
+		),
+		want: podSpec(
+			[]corev1.Container{
+				servingContainer(func(container *corev1.Container) {
+					container.Image = "busybox@sha256:deadbeef"
+				}),
+				sidecarContainer(sidecarContainerName, func(c *corev1.Container) {
+					c.Image = "ubuntu@sha256:deadbeef"
+				}),
+				queueContainer(func(container *corev1.Container) {
+					container.VolumeMounts = []corev1.VolumeMount{{
+						Name:      varTokenVolume.Name,
+						MountPath: "/var/run/secrets/tokens",
+					}}
+				},
+					withEnvVar("CONCURRENCY_STATE_ENDPOINT", `freeze-proxy`),
+				),
+			},
+			withAppendedVolumes(varTokenVolume),
+		),
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := revConfig()
 			cfg.Observability = &test.oc
-			if test.dc != nil {
-				cfg.Defaults = test.dc
+			cfg.Deployment = &test.dc
+			if test.defaults != nil {
+				cfg.Defaults = test.defaults
 			}
 			got, err := makePodSpec(test.rev, cfg)
 			if err != nil {


### PR DESCRIPTION
### Proposed Changes

* define three kinds of error, internalError/responseStatusConflictError/responseExecError
* for internalErro, such as json decode error, it should retry to call the function.
* for responseStatusConflictError, this happen when the container is in paused state when call pause(which means the daemon part should check the state when really pause/unpause the container).
* for responseExecError, this is happen when the container exec command failed.